### PR TITLE
extern-ify some vars in ross-extern.h

### DIFF
--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -55,8 +55,8 @@ extern tw_node g_tw_masternode;
 
 extern FILE		*g_tw_csv;
 
-tw_lptype * g_tw_lp_types;
-tw_typemap_f g_tw_lp_typemap;
+extern tw_lptype * g_tw_lp_types;
+extern tw_typemap_f g_tw_lp_typemap;
 
         /*
 	 * Cycle Counter variables


### PR DESCRIPTION
In some cases, linker errors have ensued from duplicate symbols.