### PR TITLE
fix for #46

### DIFF
--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -284,7 +284,7 @@ recv_begin(tw_pe *me)
 
       if(flag)
 	{
-	  if(me->abort_event == (e = tw_event_grab(me)))
+	  if(!(e = tw_event_grab(me)))
 	    {
 	      if(tw_gvt_inprogress(me))
 		tw_error(TW_LOC, "out of events in GVT!");

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -25,9 +25,7 @@ tw_event_grab(tw_pe *pe)
 	  e->memory = NULL;
 	}
 #endif
-    } else
-    e = pe->abort_event;
-
+    }
   return e;
 }
 
@@ -73,6 +71,16 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
     send_pe->stats.s_events_past_end++;
   } else {
     e = tw_event_grab(send_pe);
+    if (!e) {
+        if (g_tw_synchronization_protocol == CONSERVATIVE
+                || g_tw_synchronization_protocol == SEQUENTIAL) {
+        tw_error(TW_LOC,
+                "No free event buffers. Try increasing via g_tw_events_per_pe"
+                " or --extramem");
+        }
+        else
+            e = send_pe->abort_event;
+    }
   }
 
   e->dest_lp = (tw_lp *) dest_gid;


### PR DESCRIPTION
It follows my comment on #46. Behavior-wise, it only changes tw_event_new's treatment of OOM in conservative and sequential modes. Tested successfully on the CODES suite. My student will test it on his torus simulation code later on, which has been exhibiting the silent errors.