### PR TITLE
New Realtime GVT Scheduler, synch=5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
  - sudo apt-get install -y -qq lcov curl doxygen graphviz
  - lscpu
  - CLOCK_SPEED=`lscpu | grep "MHz" | awk '{print $3*1000*1000}'`
+ - echo $CLOCK_SPEED
  - sh ./conf/travis-install-mpi.sh mpich2
 script:
  - mkdir release && cd release

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
  - sudo apt-add-repository -y ppa:libreoffice/libreoffice-4-2
  - sudo apt-get update -q
  - sudo apt-get install -y -qq lcov curl doxygen graphviz
+ - lscpu
  - sh ./conf/travis-install-mpi.sh mpich2
 script:
  - mkdir release && cd release

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
  - sudo apt-get update -q
  - sudo apt-get install -y -qq lcov curl doxygen graphviz
  - lscpu
+ - CLOCK_SPEED=`lscpu | grep "MHz" | awk '{print $3*1000*1000}'`
  - sh ./conf/travis-install-mpi.sh mpich2
 script:
  - mkdir release && cd release

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -12,9 +12,8 @@ static unsigned int gvt_force = 0;
 static const tw_optdef gvt_opts [] =
 {
 	TWOPT_GROUP("ROSS MPI GVT"),
-	TWOPT_UINT("gvt-interval", g_tw_gvt_interval, "GVT Interval"),
-	TWOPT_ULONGLONG("gvt-realtime-interval", g_tw_gvt_realtime_interval, "GVT Realtime Interval"),
-	TWOPT_STIME("report-interval", gvt_print_interval, 
+	TWOPT_UINT("gvt-interval", g_tw_gvt_interval, "GVT Interval: Iterations through scheduling loop (synch=1,2,3,4), or ms between GVTs (synch=5)"),
+	TWOPT_STIME("report-interval", gvt_print_interval,
 			"percent of runtime to print GVT"),
 	TWOPT_END()
 };

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -13,6 +13,7 @@ static const tw_optdef gvt_opts [] =
 {
 	TWOPT_GROUP("ROSS MPI GVT"),
 	TWOPT_UINT("gvt-interval", g_tw_gvt_interval, "GVT Interval"),
+	TWOPT_ULONGLONG("gvt-realtime-interval", g_tw_gvt_realtime_interval, "GVT Realtime Interval"),
 	TWOPT_STIME("report-interval", gvt_print_interval, 
 			"percent of runtime to print GVT"),
 	TWOPT_END()
@@ -39,10 +40,19 @@ tw_gvt_force_update(tw_pe *me)
 }
 
 void
+tw_gvt_force_update_realtime(tw_pe *me)
+{
+	gvt_force++;
+        g_tw_gvt_interval_start_cycles = 0; // reset to start of time
+}
+
+void
 tw_gvt_stats(FILE * f)
 {
 	fprintf(f, "\nTW GVT Statistics: MPI AllReduce\n");
 	fprintf(f, "\t%-50s %11d\n", "GVT Interval", g_tw_gvt_interval);
+	fprintf(f, "\t%-50s %llu\n", "GVT Real Time Interval (cycles)", g_tw_gvt_realtime_interval);
+	fprintf(f, "\t%-50s %11.8lf\n", "GVT Real Time Interval (sec)", (double)g_tw_gvt_realtime_interval/(double)g_tw_clock_rate);
 	fprintf(f, "\t%-50s %11d\n", "Batch Size", g_tw_mblock);
 	fprintf(f, "\n");
 	fprintf(f, "\t%-50s %11d\n", "Forced GVT", gvt_force);
@@ -61,6 +71,28 @@ tw_gvt_step1(tw_pe *me)
 
 	me->gvt_status = TW_GVT_COMPUTE;
 }
+
+void
+tw_gvt_step1_realtime(tw_pe *me)
+{
+  unsigned long long current_rt;
+
+  if( (me->gvt_status == TW_GVT_COMPUTE) ||
+      ( (current_rt = tw_clock_read()) - g_tw_gvt_interval_start_cycles < g_tw_gvt_realtime_interval))
+    {
+      /* if( me->node == 0 ) */
+      /* 	{ */
+      /* 	  printf("GVT Step 1 RT Rank %ld: found start_cycles at %llu, rt interval at %llu, current time at %llu \n", */
+      /* 		 me->node, g_tw_gvt_interval_start_cycles, g_tw_gvt_realtime_interval, current_rt); */
+
+      /* 	} */
+
+    return;
+    }
+
+  me->gvt_status = TW_GVT_COMPUTE;
+}
+
 
 void
 tw_gvt_step2(tw_pe *me)
@@ -158,8 +190,9 @@ tw_gvt_step2(tw_pe *me)
 	// update GVT timing stats
 	me->stats.s_gvt += tw_clock_read() - start;
 
-	// only FC if OPTIMISTIC
-	if( g_tw_synchronization_protocol == OPTIMISTIC )
+	// only FC if OPTIMISTIC or REALTIME, do not do for DEBUG MODE
+	if( g_tw_synchronization_protocol == OPTIMISTIC ||
+	    g_tw_synchronization_protocol == OPTIMISTIC_REALTIME )
 	  {
 	    start = tw_clock_read();
 	    tw_pe_fossil_collect(me);
@@ -167,4 +200,7 @@ tw_gvt_step2(tw_pe *me)
 	  }
 
 	g_tw_gvt_done++;
-}
+
+	// reset for the next gvt round -- for use in realtime GVT mode only!!
+	g_tw_gvt_interval_start_cycles = tw_clock_read();
+ }

--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -58,7 +58,7 @@ tw_gvt_stats(FILE * f)
 	fprintf(f, "\t%-50s %11d\n", "Forced GVT", gvt_force);
 	fprintf(f, "\t%-50s %11d\n", "Total GVT Computations", g_tw_gvt_done);
 	fprintf(f, "\t%-50s %11lld\n", "Total All Reduce Calls", all_reduce_cnt);
-	fprintf(f, "\t%-50s %11.2lf\n", "Average Reduction / GVT", 
+	fprintf(f, "\t%-50s %11.2lf\n", "Average Reduction / GVT",
 			(double) ((double) all_reduce_cnt / (double) g_tw_gvt_done));
 }
 
@@ -114,7 +114,7 @@ tw_gvt_step2(tw_pe *me)
 	while(1)
 	  {
 	    tw_net_read(me);
-	
+
 	    // send message counts to create consistent cut
 	    local_white = me->s_nwhite_sent - me->s_nwhite_recv;
 	    all_reduce_cnt++;
@@ -126,7 +126,7 @@ tw_gvt_step2(tw_pe *me)
 			     MPI_SUM,
 			     MPI_COMM_WORLD) != MPI_SUCCESS)
 	      tw_error(TW_LOC, "MPI_Allreduce for GVT failed");
-	    
+
 	    if(total_white == 0)
 	      break;
 	  }

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -127,7 +127,9 @@ tw_net_start(void)
   tw_pe_init(0, g_tw_mynode);
 
   //If we're in (some variation of) optimistic mode, we need this hash
-  if (g_tw_synchronization_protocol == OPTIMISTIC || g_tw_synchronization_protocol == OPTIMISTIC_DEBUG) {
+  if (g_tw_synchronization_protocol == OPTIMISTIC ||
+      g_tw_synchronization_protocol == OPTIMISTIC_DEBUG ||
+      g_tw_synchronization_protocol == OPTIMISTIC_REALTIME) {
     g_tw_pe[0]->hash_t = tw_hash_create();
   } else {
     g_tw_pe[0]->hash_t = NULL;
@@ -350,6 +352,9 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
   me->stats.s_nread_network++;
   me->s_nwhite_recv++;
 
+  //  printf("recv_finish: remote event [cancel %u] FROM: LP %lu, PE %lu, TO: LP %lu, PE %lu at TS %lf \n",
+  //	 e->state.cancel_q, (tw_lpid)e->src_lp, e->send_pe, (tw_lpid)e->dest_lp, me->id, e->recv_ts);
+
   e->dest_lp = tw_getlocal_lp((tw_lpid) e->dest_lp);
   dest_pe = e->dest_lp->pe;
 
@@ -359,6 +364,8 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
   e->cancel_next = NULL;
   e->caused_by_me = NULL;
   e->cause_next = NULL;
+
+
 
   if(e->recv_ts < me->GVT)
     tw_error(TW_LOC, "%d: Received straggler from %d: %lf (%d)", 
@@ -389,7 +396,9 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
       return;
     }
 
-  if (g_tw_synchronization_protocol == OPTIMISTIC || g_tw_synchronization_protocol == OPTIMISTIC_DEBUG) {
+  if (g_tw_synchronization_protocol == OPTIMISTIC ||
+      g_tw_synchronization_protocol == OPTIMISTIC_DEBUG ||
+      g_tw_synchronization_protocol == OPTIMISTIC_REALTIME ) {
     tw_hash_insert(me->hash_t, e, e->send_pe);
     e->state.remote = 1;
   }

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -149,6 +149,7 @@ extern void tw_scheduler_sequential(tw_pe * me);
 extern void tw_scheduler_conservative(tw_pe * me);
 extern void tw_scheduler_optimistic(tw_pe * me);
 extern void tw_scheduler_optimistic_debug(tw_pe * me);
+extern void tw_scheduler_optimistic_realtime(tw_pe * me);
 
 /*
  * tw-signal.c

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -26,6 +26,8 @@ extern tw_lpid		g_tw_rng_default;
 extern tw_seed		g_tw_rng_seed;
 extern unsigned int	g_tw_mblock;
 extern unsigned int g_tw_gvt_interval;
+extern unsigned long long g_tw_gvt_realtime_interval;
+extern unsigned long long g_tw_gvt_interval_start_cycles;
 extern tw_stime		g_tw_ts_end;
 extern unsigned int	g_tw_sim_started;
 extern size_t		g_tw_msg_sz;

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -147,8 +147,6 @@ extern void tw_scheduler_sequential(tw_pe * me);
 extern void tw_scheduler_conservative(tw_pe * me);
 extern void tw_scheduler_optimistic(tw_pe * me);
 extern void tw_scheduler_optimistic_debug(tw_pe * me);
-extern void tw_scheduler_sequential_omnet(tw_pe * me);
-extern void tw_scheduler_conservative_omnet(tw_pe * me);
 
 /*
  * tw-signal.c

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -69,7 +69,7 @@ tw_stime g_tw_min_detected_offset=DBL_MAX;
 unsigned int g_tw_mblock = 16;
 unsigned int g_tw_gvt_interval = 16;
 
-unsigned long long g_tw_gvt_realtime_interval = (unsigned long long)1 * (unsigned long long)3600000; // 1ms in cycles at 3.6GHz
+unsigned long long g_tw_gvt_realtime_interval; // calculated at runtime
 unsigned long long g_tw_gvt_interval_start_cycles = 0;
 
 tw_stime     g_tw_ts_end = 100000.0;

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -68,6 +68,10 @@ tw_stime g_tw_min_detected_offset=DBL_MAX;
 	 */
 unsigned int g_tw_mblock = 16;
 unsigned int g_tw_gvt_interval = 16;
+
+unsigned long long g_tw_gvt_realtime_interval = (unsigned long long)1 * (unsigned long long)3600000; // 1ms in cycles at 3.6GHz
+unsigned long long g_tw_gvt_interval_start_cycles = 0;
+
 tw_stime     g_tw_ts_end = 100000.0;
 
 	/*

--- a/core/ross-gvt.h
+++ b/core/ross-gvt.h
@@ -17,6 +17,7 @@ extern void tw_gvt_start(void);
  * stage 2: compute GVT
  */
 extern void tw_gvt_step1(tw_pe *);
+extern void tw_gvt_step1_realtime(tw_pe *);
 extern void tw_gvt_step2(tw_pe *);
 
 /*
@@ -24,6 +25,7 @@ extern void tw_gvt_step2(tw_pe *);
  * GVT interval (optional)
  */
 extern void tw_gvt_force_update(tw_pe *);
+extern void tw_gvt_force_update_realtime(tw_pe *);
 
 /* Set the PE GVT value */
 extern int tw_gvt_set(tw_pe * pe, tw_stime LVT);

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -34,6 +34,7 @@ enum tw_synch_e {
     CONSERVATIVE,
     OPTIMISTIC,
     OPTIMISTIC_DEBUG,
+    OPTIMISTIC_REALTIME,
 };
 
 typedef enum tw_synch_e tw_synch;

--- a/core/tw-kp.c
+++ b/core/tw-kp.c
@@ -134,7 +134,9 @@ tw_init_kps(tw_pe * me)
 		kp->s_rb_total = 0;
 		kp->s_rb_secondary = 0;
 		prev_kp = kp;
-        if (g_tw_synchronization_protocol == OPTIMISTIC) {
+        if (g_tw_synchronization_protocol == OPTIMISTIC ||
+	    g_tw_synchronization_protocol == OPTIMISTIC_DEBUG ||
+	    g_tw_synchronization_protocol == OPTIMISTIC_REALTIME) {
             kp->output = init_output_messages(kp);
         }
 

--- a/core/tw-opts.c
+++ b/core/tw-opts.c
@@ -49,6 +49,7 @@ show_help(void)
 			switch (def->type)
 			{
 			case TWOPTTYPE_ULONG:
+			case TWOPTTYPE_ULONGLONG:
 			case TWOPTTYPE_UINT:
 				pos += fprintf(stderr, "=n");
 				break;
@@ -85,6 +86,10 @@ show_help(void)
 				{
 				case TWOPTTYPE_ULONG:
 					fprintf(stderr, " (default %lu)", *((unsigned long*)def->value));
+					break;
+
+				case TWOPTTYPE_ULONGLONG:
+					fprintf(stderr, " (default %llu)", *((unsigned long long*)def->value));
 					break;
 
 				case TWOPTTYPE_UINT:
@@ -159,6 +164,10 @@ void tw_opt_settings(FILE *outfile) {
                     fprintf(outfile, "%lu", *((unsigned long*)def->value));
                     break;
 
+                case TWOPTTYPE_ULONGLONG:
+                    fprintf(outfile, "%llu", *((unsigned long long*)def->value));
+                    break;
+
                 case TWOPTTYPE_UINT:
                     fprintf(outfile, "%u", *((unsigned int*)def->value));
                     break;
@@ -216,6 +225,10 @@ tw_opt_print(void)
 					fprintf(f, "%lu,", *((unsigned long*)def->value));
 					break;
 
+				case TWOPTTYPE_ULONGLONG:
+					fprintf(f, "%llu,", *((unsigned long long*)def->value));
+					break;
+
 				case TWOPTTYPE_UINT:
 					fprintf(f, "%u,", *((unsigned int*)def->value));
 					break;
@@ -260,6 +273,7 @@ apply_opt(const tw_optdef *def, const char *value)
 	switch (def->type)
 	{
 	case TWOPTTYPE_ULONG:
+	case TWOPTTYPE_ULONGLONG:
 	case TWOPTTYPE_UINT:
 	{
 		unsigned long v;
@@ -275,6 +289,10 @@ apply_opt(const tw_optdef *def, const char *value)
 		case TWOPTTYPE_ULONG:
 			*((unsigned long*)def->value) = v;
 			break;
+		case TWOPTTYPE_ULONGLONG:
+			*((unsigned long long*)def->value) = v;
+			break;
+
 		case TWOPTTYPE_UINT:
 			*((unsigned int*)def->value) = (unsigned int)v;
 			break;

--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -4,11 +4,12 @@
 enum tw_opttype
 {
 	TWOPTTYPE_GROUP = 1,
-	TWOPTTYPE_ULONG,   /**< value must be an "unsigned long*" */
-	TWOPTTYPE_UINT,    /**< value must be an "unsigned int*" */
-	TWOPTTYPE_STIME,   /**< value must be an "tw_stime*" */
-	TWOPTTYPE_CHAR,    /**< value must be a char * */
-        TWOPTTYPE_FLAG,    /**< value must be at "unsigned int*" */
+	TWOPTTYPE_ULONG,       /**< value must be an "unsigned long*" */
+	TWOPTTYPE_ULONGLONG,   /**< value must be an "unsigned long long*" */
+	TWOPTTYPE_UINT,        /**< value must be an "unsigned int*" */
+	TWOPTTYPE_STIME,       /**< value must be an "tw_stime*" */
+	TWOPTTYPE_CHAR,        /**< value must be a char * */
+        TWOPTTYPE_FLAG,        /**< value must be at "unsigned int*" */
 	TWOPTTYPE_SHOWHELP
 };
 typedef enum tw_opttype tw_opttype;
@@ -24,6 +25,7 @@ struct tw_optdef
 
 #define TWOPT_GROUP(h)     { TWOPTTYPE_GROUP, NULL, (h), NULL }
 #define TWOPT_ULONG(n,v,h) { TWOPTTYPE_ULONG, (n), (h), &(v) }
+#define TWOPT_ULONGLONG(n,v,h) { TWOPTTYPE_ULONGLONG, (n), (h), &(v) }
 #define TWOPT_UINT(n,v,h)  { TWOPTTYPE_UINT,  (n), (h), &(v) }
 #define TWOPT_STIME(n,v,h) { TWOPTTYPE_STIME, (n), (h), &(v) }
 #define TWOPT_CHAR(n,v,h)  { TWOPTTYPE_CHAR,  (n), (h), &(v) }

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -237,6 +237,111 @@ static void tw_sched_batch(tw_pe * me) {
     }
 }
 
+static void tw_sched_batch_realtime(tw_pe * me) {
+    /* Number of consecutive times we gave up because there were no free event buffers. */
+    static int no_free_event_buffers = 0;
+    static int warned_no_free_event_buffers = 0;
+    const int max_alloc_fail_count = 20;
+
+    tw_clock     start;
+    unsigned int     msg_i;
+
+    /* Process g_tw_mblock events, or until the PQ is empty
+    * (whichever comes first).
+    */
+    for (msg_i = g_tw_mblock; msg_i; msg_i--) {
+        tw_event *cev;
+        tw_lp *clp;
+        tw_kp *ckp;
+
+        /* OUT OF FREE EVENT BUFFERS.  BAD.
+        * Go do fossil collect immediately.
+        */
+        if (me->free_q.size <= g_tw_gvt_threshold) {
+            /* Suggested by Adam Crume */
+            if (++no_free_event_buffers > 10) {
+                if (!warned_no_free_event_buffers) {
+                    fprintf(stderr, "WARNING: No free event buffers.  Try increasing memory via the --extramem option.\n");
+                    warned_no_free_event_buffers = 1;
+                }
+                if (no_free_event_buffers >= max_alloc_fail_count) {
+                    tw_error(TW_LOC, "Event allocation failed %d consecutive times.  Exiting.", max_alloc_fail_count);
+                }
+            }
+            tw_gvt_force_update_realtime(me);
+            break;
+        }
+        no_free_event_buffers = 0;
+
+        start = tw_clock_read();
+        if (!(cev = tw_pq_dequeue(me->pq))) {
+	  break; // leave the batch function
+        }
+        me->stats.s_pq += tw_clock_read() - start;
+        if(cev->recv_ts == tw_pq_minimum(me->pq)) {
+            me->stats.s_pe_event_ties++;
+        }
+
+        clp = cev->dest_lp;
+
+	ckp = clp->kp;
+	me->cur_event = cev;
+	ckp->last_time = cev->recv_ts;
+
+	/* Save state if no reverse computation is available */
+	if (!clp->type->revent) {
+	  tw_error(TW_LOC, "Reverse Computation must be implemented!");
+	}
+
+	start = tw_clock_read();
+
+	reset_bitfields(cev);
+
+	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
+	if( !(clp->suspend_flag) )
+	  {
+	    (*clp->type->event)(clp->cur_state, &cev->cv,
+				tw_event_data(cev), clp);
+	  }
+	ckp->s_nevent_processed++;
+	me->stats.s_event_process += tw_clock_read() - start;
+
+	/* We ran out of events while processing this event.  We
+	 * cannot continue without doing GVT and fossil collect.
+	 */
+
+	if (me->cev_abort)
+	  {
+	    start = tw_clock_read();
+	    me->stats.s_nevent_abort++;
+	    me->cev_abort = 0;
+
+	    tw_event_rollback(cev);
+	    tw_pq_enqueue(me->pq, cev);
+
+	    cev = tw_eventq_peek(&ckp->pevent_q);
+	    ckp->last_time = cev ? cev->recv_ts : me->GVT;
+
+	    tw_gvt_force_update_realtime(me);
+
+	    me->stats.s_event_abort += tw_clock_read() - start;
+
+	    break; // leave the batch function
+	  } // END ABORT CHECK
+
+	/* Thread current event into processed queue of kp */
+        cev->state.owner = TW_kp_pevent_q;
+        tw_eventq_unshift(&ckp->pevent_q, cev);
+
+	/* Check if realtime GVT time interval has expired */
+	if( tw_clock_read() - g_tw_gvt_interval_start_cycles > g_tw_gvt_realtime_interval)
+	  {
+	    tw_gvt_force_update_realtime(me);
+	    break; // leave the batch function
+	  }
+    }
+}
+
 void tw_sched_init(tw_pe * me) {
     /* First Stage Init */
     (*me->type.pre_lp_init)(me);
@@ -448,6 +553,53 @@ void tw_scheduler_optimistic(tw_pe * me) {
         }
 
         tw_sched_batch(me);
+    }
+
+    tw_wall_now(&me->end_time);
+    me->stats.s_total = tw_clock_read() - me->stats.s_total;
+
+    if ((g_tw_mynode == g_tw_masternode) && me->local_master) {
+        printf("*** END SIMULATION ***\n\n");
+    }
+
+    tw_net_barrier(me);
+
+    // call the model PE finalize function
+    (*me->type.final)(me);
+
+    tw_stats(me);
+}
+
+void tw_scheduler_optimistic_realtime(tw_pe * me) {
+    tw_clock start;
+
+    if ((g_tw_mynode == g_tw_masternode) && me->local_master) {
+        printf("*** START PARALLEL OPTIMISTIC SIMULATION WITH SUSPEND LP FEATURE AND REAL TIME GVT ***\n\n");
+    }
+
+    tw_wall_now(&me->start_time);
+    me->stats.s_total = tw_clock_read();
+
+    // init the realtime GVT
+    g_tw_gvt_interval_start_cycles = tw_clock_read();
+
+    for (;;) {
+        if (tw_nnodes() > 1) {
+            start = tw_clock_read();
+            tw_net_read(me);
+            me->stats.s_net_read += tw_clock_read() - start;
+        }
+
+        tw_gvt_step1_realtime(me);
+        tw_sched_event_q(me);
+        tw_sched_cancel_q(me);
+        tw_gvt_step2(me); // use regular step2 at this point
+
+        if (me->GVT > g_tw_ts_end) {
+            break;
+        }
+
+        tw_sched_batch_realtime(me);
     }
 
     tw_wall_now(&me->end_time);

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -190,44 +190,44 @@ static void tw_sched_batch(tw_pe * me) {
 	ckp = clp->kp;
 	me->cur_event = cev;
 	ckp->last_time = cev->recv_ts;
-	
+
 	/* Save state if no reverse computation is available */
 	if (!clp->type->revent) {
 	  tw_error(TW_LOC, "Reverse Computation must be implemented!");
 	}
-	    
+
 	start = tw_clock_read();
 	reset_bitfields(cev);
 
 	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
 	if( !(clp->suspend_flag) )
 	  {
-	    (*clp->type->event)(clp->cur_state, &cev->cv, 
+	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
 	  }
 	ckp->s_nevent_processed++;
 	me->stats.s_event_process += tw_clock_read() - start;
-	    
+
 	/* We ran out of events while processing this event.  We
 	 * cannot continue without doing GVT and fossil collect.
 	 */
-	
-	if (me->cev_abort) 
+
+	if (me->cev_abort)
 	  {
 	    start = tw_clock_read();
 	    me->stats.s_nevent_abort++;
 	    me->cev_abort = 0;
-	    
+
 	    tw_event_rollback(cev);
 	    tw_pq_enqueue(me->pq, cev);
-	    
+
 	    cev = tw_eventq_peek(&ckp->pevent_q);
 	    ckp->last_time = cev ? cev->recv_ts : me->GVT;
-	    
+
 	    tw_gvt_force_update(me);
-	    
+
 	    me->stats.s_event_abort += tw_clock_read() - start;
-	    
+
 	    break;
 	  } // END ABORT CHECK
 
@@ -666,13 +666,13 @@ void tw_scheduler_optimistic_debug(tw_pe * me) {
             break;
         }
     }
-    
+
     // If we've run out of free events or events to process (maybe we're past end time?)
     // Perform all the rollbacks!
     printf("/******************* Starting Rollback Phase ******************************/\n");
     tw_kp_rollback_to( g_tw_kp[0], g_tw_rollback_time );
     printf("/******************* Completed Rollback Phase ******************************/\n");
-    
+
     tw_wall_now(&me->end_time);
 
     printf("*** END SIMULATION ***\n\n");

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -573,6 +573,8 @@ void tw_scheduler_optimistic(tw_pe * me) {
 void tw_scheduler_optimistic_realtime(tw_pe * me) {
     tw_clock start;
 
+    g_tw_gvt_realtime_interval = g_tw_gvt_interval * g_tw_clock_rate / 1000;
+
     if ((g_tw_mynode == g_tw_masternode) && me->local_master) {
         printf("*** START PARALLEL OPTIMISTIC SIMULATION WITH SUSPEND LP FEATURE AND REAL TIME GVT ***\n\n");
     }

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -13,7 +13,7 @@ unsigned int nkp_per_pe = 16;
 
 static const tw_optdef kernel_options[] = {
     TWOPT_GROUP("ROSS Kernel"),
-    TWOPT_UINT("synch", g_tw_synchronization_protocol, "Sychronization Protocol: SEQUENTIAL=1, CONSERVATIVE=2, OPTIMISTIC=3, OPTIMISTIC_DEBUG=4"),
+    TWOPT_UINT("synch", g_tw_synchronization_protocol, "Sychronization Protocol: SEQUENTIAL=1, CONSERVATIVE=2, OPTIMISTIC=3, OPTIMISTIC_DEBUG=4, OPTIMISTIC_REALTIME=5"),
     TWOPT_UINT("nkp", nkp_per_pe, "number of kernel processes (KPs) per pe"),
     TWOPT_STIME("end", g_tw_ts_end, "simulation end timestamp"),
     TWOPT_UINT("batch", g_tw_mblock, "messages per scheduler block"),
@@ -331,20 +331,24 @@ void tw_run(void) {
     tw_sched_init(me);
 
     switch(g_tw_synchronization_protocol) {
-        case SEQUENTIAL:    // case 1
+        case SEQUENTIAL:            // case 1
             tw_scheduler_sequential(me);
             break;
 
-        case CONSERVATIVE: // case 2
+        case CONSERVATIVE:         // case 2
             tw_scheduler_conservative(me);
             break;
 
-        case OPTIMISTIC:   // case 3
+        case OPTIMISTIC:          // case 3
             tw_scheduler_optimistic(me);
             break;
 
-        case OPTIMISTIC_DEBUG:  // case 4
+        case OPTIMISTIC_DEBUG:    // case 4
             tw_scheduler_optimistic_debug(me);
+            break;
+
+        case OPTIMISTIC_REALTIME: // case 5
+            tw_scheduler_optimistic_realtime(me);
             break;
 
         default:

--- a/core/tw-util.c
+++ b/core/tw-util.c
@@ -12,7 +12,7 @@ tw_output(tw_lp *lp, const char *fmt, ...)
     tw_event *cev;
     tw_out *temp;
 
-    if (g_tw_synchronization_protocol != OPTIMISTIC) {
+    if (g_tw_synchronization_protocol == SEQUENTIAL || g_tw_synchronization_protocol == CONSERVATIVE) {
         va_start(ap, fmt);
         vfprintf(stdout, fmt, ap);
         va_end(ap);

--- a/models/phold/CMakeLists.txt
+++ b/models/phold/CMakeLists.txt
@@ -22,5 +22,7 @@ add_test(PholdConservative mpirun -np 2 ./phold --synch=2)
 
 add_test(PholdOptimistic mpirun -np 2 ./phold --synch=3)
 
+add_test(PholdRealtime mpirun -np 2 ./phold --synch=5 --gvt-realtime-interval=3600000 --clock-rate=$ENV{CLOCK_SPEED})
+
 # For our optimistic debug bug :)
 add_test(PholdOptDebug phold --synch=4 --nkp=1 --extramem=1000000)

--- a/models/phold/CMakeLists.txt
+++ b/models/phold/CMakeLists.txt
@@ -22,7 +22,7 @@ add_test(PholdConservative mpirun -np 2 ./phold --synch=2)
 
 add_test(PholdOptimistic mpirun -np 2 ./phold --synch=3)
 
-add_test(PholdRealtime mpirun -np 2 ./phold --synch=5 --gvt-realtime-interval=3600000 --clock-rate=$ENV{CLOCK_SPEED})
+add_test(PholdRealtime mpirun -np 2 ./phold --synch=5 --gvt-interval=1 --clock-rate=$ENV{CLOCK_SPEED})
 
 # For our optimistic debug bug :)
 add_test(PholdOptDebug phold --synch=4 --nkp=1 --extramem=1000000)


### PR DESCRIPTION
Hi all;

A new ROSS "realtime" scheduler is available that computes GVT at a set realtime interval. This is for applications that have either wild rollback behaviors or a good amount of variance in the time to compute a single event.  An example PHOLD run command line is as follows:

mpirun -np 4 ./phold --synch=5 --extramem=65536 --nlp=1024 --batch=32 --gvt-interval=256 --gvt-realtime-interval=3600000 --clock-rate=3600000000 --start-events=16  --lookahead=0.10 --end=2000 > results-sync-5

Note, above you are using the new Real Time scheduler with --synch=5. Here, the --gvt-realtime-interval is the number of clock cycles between successive GVTs. So, you need to set the clock rate of
the processor you are using via --clock-rate. 

To which back to using the original ROSS optimistic schedule, just use:

mpirun -np 4 ./phold --synch=3 --extramem=65536 --nlp=1024 --batch=32 --gvt-interval=256 --gvt-realtime-interval=3600000 --clock-rate=3600000000 --start-events=16  --lookahead=0.10 --end=2000 > results-sync

Notice, they only thing that chance is the --sync option. This is because you can keep realtime
and original GVT interval settings for both command lines and the scheduler determines which set of options to us (either gvt-interval or gvt-realtime-interval). 

Enjoy!,
Chris