### PR TITLE
squash some warnings

### DIFF
--- a/core/ross-kernel-inline.h
+++ b/core/ross-kernel-inline.h
@@ -7,7 +7,7 @@
 static inline tw_lp * 
      tw_getlocal_lp(tw_lpid gid)
 {
-  long id;
+  tw_lpid id;
 
 
   switch (g_tw_mapping) {

--- a/core/tw-eventq.h
+++ b/core/tw-eventq.h
@@ -34,6 +34,8 @@ tw_eventq_debug(tw_eventq * q)
 
   if(cnt != q->size)
     tw_error(TW_LOC, "Size not correct!");	
+#else
+  (void)q; // avoid "unused parameter" warning
 #endif
 }
 

--- a/core/tw-opts.h
+++ b/core/tw-opts.h
@@ -28,7 +28,7 @@ struct tw_optdef
 #define TWOPT_STIME(n,v,h) { TWOPTTYPE_STIME, (n), (h), &(v) }
 #define TWOPT_CHAR(n,v,h)  { TWOPTTYPE_CHAR,  (n), (h), &(v) }
 #define TWOPT_FLAG(n,v,h)  { TWOPTTYPE_FLAG,  (n), (h), &(v) }
-#define TWOPT_END()        { (tw_opttype)0 }
+#define TWOPT_END()        { (tw_opttype)0,   NULL, NULL, NULL }
 
 /** Remove options from the command line arguments. */
 extern void tw_opt_parse(int *argc, char ***argv);


### PR DESCRIPTION
Seen in CODES source by using -Wextra on compilations (due to these functions/macros being inline).