### PR TITLE
Lamport path

### DIFF
--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -117,6 +117,7 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
   e->dest_lp = (tw_lp *) dest_gid;
   e->src_lp = sender;
   e->recv_ts = recv_ts;
+  e->critical_path = sender->critical_path + 1;
 
   tw_free_output_messages(e, 0);
 

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -299,6 +299,8 @@ struct tw_event {
     void *delta_buddy;              /**< @brief Delta memory from buddy allocator. */
     size_t      delta_size;         /**< @brief Size of delta. */
 
+    unsigned int critical_path;     /**< @brief Critical path of this event */
+
     tw_lp       *dest_lp;           /**< @brief Destination LP ID */
     tw_lp       *src_lp;            /**< @brief Sending LP ID */
     tw_stime     recv_ts;           /**< @brief Actual time to be received */
@@ -337,6 +339,8 @@ struct tw_lp {
     void *cur_state; /**< @brief Current application LP data */
     tw_lptype  *type; /**< @brief Type of this LP, including service callbacks */
     tw_rng_stream *rng; /**< @brief  RNG stream array for this LP */
+
+    unsigned int critical_path; /**< @brief Critical path value for this LP */
 
   /* tw_suspend variables */
   tw_event    *suspend_event;

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -184,6 +184,9 @@ void tw_event_rollback(tw_event * event) {
 
     (*dest_lp->type->revent)(dest_lp->cur_state, &event->cv, tw_event_data(event), dest_lp);
 
+    // reset critical path
+    dest_lp->critical_path = event->critical_path;
+
 jump_over_rc_event_handler:
     if (event->delta_buddy) {
         tw_clock start = tw_clock_read();

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -157,7 +157,7 @@ void tw_event_rollback(tw_event * event) {
     dest_lp->kp->last_time = event->recv_ts;
 
     if( dest_lp->suspend_flag &&
-	dest_lp->suspend_event == event && 
+	dest_lp->suspend_event == event &&
 	// Must test time stamp since events are reused once GVT sweeps by
 	dest_lp->suspend_time == event->recv_ts)
       {
@@ -172,7 +172,7 @@ void tw_event_rollback(tw_event * event) {
 	    goto jump_over_rc_event_handler;
 	  }
 	else
-	  { // reset 
+	  { // reset
 	    dest_lp->suspend_do_orig_event_rc = 0;
 	    // note, should fall thru and process reverse events
 	  }

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -204,7 +204,7 @@ static void tw_sched_batch(tw_pe * me) {
 	  {
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
-        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
         cev->critical_path = prev_cp;
@@ -306,7 +306,7 @@ static void tw_sched_batch_realtime(tw_pe * me) {
 	  {
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
-        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
         cev->critical_path = prev_cp;
@@ -421,7 +421,7 @@ void tw_scheduler_sequential(tw_pe * me) {
         }
 
         reset_bitfields(cev);
-        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
         if (me->cev_abort){
@@ -507,7 +507,7 @@ void tw_scheduler_conservative(tw_pe * me) {
 
             start = tw_clock_read();
             reset_bitfields(cev);
-            clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+            clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
             (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
             ckp->s_nevent_processed++;
@@ -668,7 +668,7 @@ void tw_scheduler_optimistic_debug(tw_pe * me) {
 
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
-        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
         cev->critical_path = prev_cp;
 

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -205,10 +205,9 @@ static void tw_sched_batch(tw_pe * me) {
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
-        cev->critical_path = prev_cp;
-
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
+        cev->critical_path = prev_cp;
 	  }
 	ckp->s_nevent_processed++;
 	me->stats.s_event_process += tw_clock_read() - start;
@@ -308,10 +307,9 @@ static void tw_sched_batch_realtime(tw_pe * me) {
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
-        cev->critical_path = prev_cp;
-
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
+        cev->critical_path = prev_cp;
 	  }
 	ckp->s_nevent_processed++;
 	me->stats.s_event_process += tw_clock_read() - start;
@@ -671,9 +669,8 @@ void tw_scheduler_optimistic_debug(tw_pe * me) {
         // state-save and update the LP's critical path
         unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
-        cev->critical_path = prev_cp;
-
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
+        cev->critical_path = prev_cp;
 
         ckp->s_nevent_processed++;
 

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -202,7 +202,11 @@ static void tw_sched_batch(tw_pe * me) {
 	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
 	if( !(clp->suspend_flag) )
 	  {
+        // state-save and update the LP's critical path
+        unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        cev->critical_path = prev_cp;
+
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
 	  }
@@ -301,7 +305,11 @@ static void tw_sched_batch_realtime(tw_pe * me) {
 	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
 	if( !(clp->suspend_flag) )
 	  {
+        // state-save and update the LP's critical path
+        unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        cev->critical_path = prev_cp;
+
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
 	  }
@@ -659,7 +667,12 @@ void tw_scheduler_optimistic_debug(tw_pe * me) {
 
         /* don't update GVT */
         reset_bitfields(cev);
+
+        // state-save and update the LP's critical path
+        unsigned int prev_cp = clp->critical_path;
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
+        cev->critical_path = prev_cp;
+
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
         ckp->s_nevent_processed++;

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -202,6 +202,7 @@ static void tw_sched_batch(tw_pe * me) {
 	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
 	if( !(clp->suspend_flag) )
 	  {
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
 	  }
@@ -300,6 +301,7 @@ static void tw_sched_batch_realtime(tw_pe * me) {
 	// if NOT A SUSPENDED LP THEN FORWARD PROC EVENTS
 	if( !(clp->suspend_flag) )
 	  {
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
 	    (*clp->type->event)(clp->cur_state, &cev->cv,
 				tw_event_data(cev), clp);
 	  }
@@ -413,6 +415,7 @@ void tw_scheduler_sequential(tw_pe * me) {
         }
 
         reset_bitfields(cev);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
         if (me->cev_abort){
@@ -498,6 +501,7 @@ void tw_scheduler_conservative(tw_pe * me) {
 
             start = tw_clock_read();
             reset_bitfields(cev);
+            clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
             (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
             ckp->s_nevent_processed++;
@@ -655,6 +659,7 @@ void tw_scheduler_optimistic_debug(tw_pe * me) {
 
         /* don't update GVT */
         reset_bitfields(cev);
+        clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path);
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
 
         ckp->s_nevent_processed++;


### PR DESCRIPTION
Adds a critical path counter to LPs and Events. This counter is updated before an event handler and is preserved across rollbacks (the counter is deterministic to the model).