### PR TITLE
RIO v2

### DIFF
--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -828,7 +828,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
             &me->stats.s_rio,
             1,
             MPI_UNSIGNED_LONG_LONG,
-            MPI_SUM,
+            MPI_MAX,
             (int)g_tw_masternode,
             MPI_COMM_WORLD) != MPI_SUCCESS)
         tw_error(TW_LOC, "Unable to reduce statistics!");

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -824,8 +824,16 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
 #ifdef USE_RIO
-    if (MPI_Reduce(&s->s_rio,
-            &me->stats.s_rio,
+    if (MPI_Reduce(&s->s_rio_load,
+            &me->stats.s_rio_load,
+            1,
+            MPI_UNSIGNED_LONG_LONG,
+            MPI_MAX,
+            (int)g_tw_masternode,
+            MPI_COMM_WORLD) != MPI_SUCCESS)
+        tw_error(TW_LOC, "Unable to reduce statistics!");
+    if (MPI_Reduce(&s->s_rio_lp_init,
+            &me->stats.s_rio_lp_init,
             1,
             MPI_UNSIGNED_LONG_LONG,
             MPI_MAX,

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -822,6 +822,17 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
         (int)g_tw_masternode,
         MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
-    
+
+#ifdef USE_RIO
+    if (MPI_Reduce(&s->s_rio,
+            &me->stats.s_rio,
+            1,
+            MPI_UNSIGNED_LONG_LONG,
+            MPI_SUM,
+            (int)g_tw_masternode,
+            MPI_COMM_WORLD) != MPI_SUCCESS)
+        tw_error(TW_LOC, "Unable to reduce statistics!");
+#endif
+
   return &me->stats;
 }

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -297,7 +297,7 @@ recv_begin(tw_pe *me)
 	}
 
 #if ROSS_MEMORY
-      if(!flag || 
+      if(!flag ||
 	 MPI_Irecv(posted_recvs.buffers[id],
 		   EVENT_SIZE(e),
 		   MPI_BYTE,
@@ -306,7 +306,7 @@ recv_begin(tw_pe *me)
 		   MPI_COMM_WORLD,
 		   &posted_recvs.req_list[id]) != MPI_SUCCESS)
 #else
-	if(!flag || 
+	if(!flag ||
 	   MPI_Irecv(e,
 		     (int)EVENT_SIZE(e),
 		     MPI_BYTE,
@@ -361,7 +361,7 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
   e->cause_next = NULL;
 
   if(e->recv_ts < me->GVT)
-    tw_error(TW_LOC, "%d: Received straggler from %d: %lf (%d)", 
+    tw_error(TW_LOC, "%d: Received straggler from %d: %lf (%d)",
 	     me->id,  e->send_pe, e->recv_ts, e->state.cancel_q);
 
   if(tw_gvt_inprogress(me))
@@ -375,7 +375,7 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
 
       // NOTE: it is possible to cancel the event we
       // are currently processing at this PE since this
-      // MPI module lets me read cancel events during 
+      // MPI module lets me read cancel events during
       // event sends over the network.
 
       cancel->state.cancel_q = 1;
@@ -439,7 +439,7 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
 
   if (me->node == dest_pe->node) {
     /* Slower, but still local send, so put into top
-     * of dest_pe->event_q. 
+     * of dest_pe->event_q.
      */
     e->state.owner = TW_pe_event_q;
     tw_eventq_push(&dest_pe->event_q, e);
@@ -742,7 +742,7 @@ tw_net_cancel(tw_event *e)
 tw_statistics	*
 tw_net_statistics(tw_pe * me, tw_statistics * s)
 {
-  if(MPI_Reduce(&(s->s_max_run_time), 
+  if(MPI_Reduce(&(s->s_max_run_time),
 		&me->stats.s_max_run_time,
 		1,
 		MPI_DOUBLE,
@@ -751,7 +751,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 		MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
-  if(MPI_Reduce(&(s->s_net_events), 
+  if(MPI_Reduce(&(s->s_net_events),
 		&me->stats.s_net_events,
 		16,
 		MPI_UNSIGNED_LONG_LONG,
@@ -760,7 +760,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 		MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
-  if(MPI_Reduce(&s->s_total, 
+  if(MPI_Reduce(&s->s_total,
 		&me->stats.s_total,
 		8,
 		MPI_UNSIGNED_LONG_LONG,
@@ -768,7 +768,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 		(int)g_tw_masternode,
 		MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
-    
+
   if(MPI_Reduce(&s->s_pe_event_ties,
         &me->stats.s_pe_event_ties,
         1,
@@ -777,7 +777,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
         (int)g_tw_masternode,
         MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
-     
+
   if(MPI_Reduce(&s->s_min_detected_offset,
         &me->stats.s_min_detected_offset,
         1,
@@ -786,7 +786,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
         (int)g_tw_masternode,
         MPI_COMM_WORLD) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
-    
+
   if(MPI_Reduce(&s->s_avl,
         &me->stats.s_avl,
         1,

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -33,6 +33,7 @@ tw_event_grab(tw_pe *pe)
 extern tw_eventq g_io_free_events;
 extern tw_eventq g_io_buffered_events;
 static inline tw_event * io_event_grab (tw_pe *pe) {
+    tw_clock start = tw_clock_read();
     tw_event  *e = tw_eventq_pop(&g_io_free_events);
 
     if (e) {
@@ -48,6 +49,7 @@ static inline tw_event * io_event_grab (tw_pe *pe) {
         printf("WARNING: did not allocate enough events to RIO buffer\n");
         e = pe->abort_event;
     }
+    pe->stats.s_rio += (tw_clock_read() - start);
     return e;
 }
 #endif

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -29,31 +29,6 @@ tw_event_grab(tw_pe *pe)
   return e;
 }
 
-#ifdef USE_RIO
-extern tw_eventq g_io_free_events;
-extern tw_eventq g_io_buffered_events;
-static inline tw_event * io_event_grab (tw_pe *pe) {
-    tw_clock start = tw_clock_read();
-    tw_event  *e = tw_eventq_pop(&g_io_free_events);
-
-    if (e) {
-        e->cancel_next = NULL;
-        e->caused_by_me = NULL;
-        e->cause_next = NULL;
-        e->prev = e->next = NULL;
-
-        memset(&e->state, 0, sizeof(e->state));
-        memset(&e->event_id, 0, sizeof(e->event_id));
-        tw_eventq_push(&g_io_buffered_events, e);
-    } else {
-        printf("WARNING: did not allocate enough events to RIO buffer\n");
-        e = pe->abort_event;
-    }
-    pe->stats.s_rio += (tw_clock_read() - start);
-    return e;
-}
-#endif
-
 static inline void
 tw_free_output_messages(tw_event *e, int print_message)
 {

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -155,7 +155,8 @@ struct tw_statistics {
     tw_stat s_events_past_end;
 
 #ifdef USE_RIO
-    tw_clock s_rio;
+    tw_clock s_rio_load;
+    tw_clock s_rio_lp_init;
 #endif
 };
 

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -153,6 +153,10 @@ struct tw_statistics {
     tw_clock s_lz4;
 
     tw_stat s_events_past_end;
+
+#ifdef USE_RIO
+    tw_clock s_rio;
+#endif
 };
 
 #ifdef ROSS_MEMORY

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -353,6 +353,7 @@ struct tw_kp {
     tw_pe *pe;      /**< @brief PE that services this KP */
     tw_kp *next;    /**< @brief Next KP in the PE's service list */
     tw_out *output; /**< @brief Output messages */
+    int lp_count;
 
 #ifdef ROSS_QUEUE_kp_splay
     tw_eventpq *pq;

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -250,7 +250,10 @@ enum tw_event_owner {
     TW_net_asend = 6,       /**< @brief Network transmission in progress */
     TW_net_acancel = 7,     /**< @brief Network transmission in progress */
     TW_pe_sevent_q = 8,     /**< @brief In tw_pe.sevent_q */
-    TW_pe_free_q = 9        /**< @brief In tw_pe.free_q */
+    TW_pe_free_q = 9,       /**< @brief In tw_pe.free_q */
+#ifdef USE_RIO
+    IO_buffer = 10,         /**< @brief RIO captured event */
+#endif
 };
 typedef enum tw_event_owner tw_event_owner;
 

--- a/core/ross.h
+++ b/core/ross.h
@@ -209,11 +209,12 @@ typedef uint64_t tw_lpid;
 #endif
 
 #include "tw-eventq.h"
-#include "ross-inline.h"
 
 #ifdef USE_RIO
 #include "../IO/io.h"
 #endif
+
+#include "ross-inline.h"
 
 #ifdef __cplusplus
 }

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -24,6 +24,7 @@ void tw_event_send(tw_event * event) {
 #ifdef USE_RIO
     // rio saves events scheduled past end time
      if (recv_ts >= g_tw_ts_end) {
+        link_causality(event, send_pe->cur_event);
         return;
     }
 #endif
@@ -107,6 +108,13 @@ static inline void event_cancel(tw_event * event) {
 
         return;
     }
+
+#ifdef USE_RIO
+    if (event->state.owner == IO_buffer) {
+        io_event_cancel(event);
+        return;
+    }
+#endif
 
     dest_peid = event->dest_lp->pe->id;
 

--- a/core/tw-lp.c
+++ b/core/tw-lp.c
@@ -106,12 +106,14 @@ tw_init_lps(tw_pe * me)
 #endif
 	}
 #ifdef USE_RIO
-	tw_clock start = tw_clock_read();
 	// RIO requires that all LPs have been allocated
 	if (g_io_load_at == PRE_INIT || g_io_load_at == INIT) {
+		tw_clock start = tw_clock_read();
         io_load_checkpoint(g_io_checkpoint_name);
+        me->stats.s_rio_load += (tw_clock_read() - start);
     }
     if (g_io_load_at != INIT) {
+    	tw_clock start = tw_clock_read();
     	for (i = 0; i < g_tw_nlp; i++) {
 			tw_lp * lp = g_tw_lp[i];
 			me->cur_event = me->abort_event;
@@ -123,11 +125,13 @@ tw_init_lps(tw_pe * me)
 				tw_error(TW_LOC, "ran out of events during init");
 			}
 		}
+		me->stats.s_rio_lp_init += (tw_clock_read() - start);
 	}
     if (g_io_load_at == POST_INIT) {
+		tw_clock start = tw_clock_read();
         io_load_checkpoint(g_io_checkpoint_name);
+        me->stats.s_rio_load += (tw_clock_read() - start);
     }
-    me->stats.s_rio += (tw_clock_read() - start);
 #endif
 }
 

--- a/core/tw-lp.c
+++ b/core/tw-lp.c
@@ -109,7 +109,7 @@ tw_init_lps(tw_pe * me)
 	// RIO requires that all LPs have been allocated
 	if (g_io_load_at == PRE_INIT || g_io_load_at == INIT) {
 		tw_clock start = tw_clock_read();
-        io_load_checkpoint(g_io_checkpoint_name);
+        io_read_checkpoint();
         me->stats.s_rio_load += (tw_clock_read() - start);
     }
     if (g_io_load_at != INIT) {
@@ -129,7 +129,7 @@ tw_init_lps(tw_pe * me)
 	}
     if (g_io_load_at == POST_INIT) {
 		tw_clock start = tw_clock_read();
-        io_load_checkpoint(g_io_checkpoint_name);
+        io_read_checkpoint();
         me->stats.s_rio_load += (tw_clock_read() - start);
     }
 #endif

--- a/core/tw-lp.c
+++ b/core/tw-lp.c
@@ -105,6 +105,7 @@ tw_init_lps(tw_pe * me)
 #endif
 	}
 #ifdef USE_RIO
+	tw_clock start = tw_clock_read();
 	// RIO requires that all LPs have been allocated
 	if (g_io_load_at == PRE_INIT || g_io_load_at == INIT) {
         io_load_checkpoint(g_io_checkpoint_name);
@@ -125,6 +126,7 @@ tw_init_lps(tw_pe * me)
     if (g_io_load_at == POST_INIT) {
         io_load_checkpoint(g_io_checkpoint_name);
     }
+    me->stats.s_rio += (tw_clock_read() - start);
 #endif
 }
 

--- a/core/tw-lp.c
+++ b/core/tw-lp.c
@@ -72,6 +72,7 @@ tw_lp_onkp(tw_lp * lp, tw_kp * kp)
 		tw_error(TW_LOC, "Bad LP pointer!");
 
 	lp->kp = kp;
+	kp->lp_count++;
 }
 
 void

--- a/core/tw-pe.c
+++ b/core/tw-pe.c
@@ -49,7 +49,7 @@ tw_pe_init(tw_peid id, tw_peid gid)
 {
         tw_pe *pe = (tw_pe *) tw_calloc(TW_LOC, "Local PE", sizeof(*pe), 1);
 	tw_petype no_type;
-	
+
 	memset(&no_type, 0, sizeof(no_type));
 
 	pe->id = gid;

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -237,8 +237,10 @@ void tw_sched_init(tw_pe * me) {
     tw_net_barrier(me);
 
 #ifdef USE_RIO
+    tw_clock start = tw_clock_read();
     io_load_events(me);
     tw_net_barrier(me);
+    me->stats.s_rio += (tw_clock_read() - start);
 #endif
 
     /*

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -239,8 +239,8 @@ void tw_sched_init(tw_pe * me) {
 #ifdef USE_RIO
     tw_clock start = tw_clock_read();
     io_load_events(me);
-    tw_net_barrier(me);
     me->stats.s_rio += (tw_clock_read() - start);
+    tw_net_barrier(me);
 #endif
 
     /*

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -278,6 +278,7 @@ void tw_scheduler_sequential(tw_pe * me) {
     printf("*** START SEQUENTIAL SIMULATION ***\n\n");
 
     tw_wall_now(&me->start_time);
+    me->stats.s_total = tw_clock_read();
 
     while ((cev = tw_pq_dequeue(me->pq))) {
         tw_lp *clp = cev->dest_lp;
@@ -306,6 +307,7 @@ void tw_scheduler_sequential(tw_pe * me) {
         tw_event_free(me, cev);
     }
     tw_wall_now(&me->end_time);
+    me->stats.s_total = tw_clock_read() - me->stats.s_total;
 
     printf("*** END SIMULATION ***\n\n");
 

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -239,7 +239,7 @@ void tw_sched_init(tw_pe * me) {
 #ifdef USE_RIO
     tw_clock start = tw_clock_read();
     io_load_events(me);
-    me->stats.s_rio += (tw_clock_read() - start);
+    me->stats.s_rio_load += (tw_clock_read() - start);
     tw_net_barrier(me);
 #endif
 

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -428,7 +428,7 @@ static tw_pe * setup_pes(void) {
         for (i = 0; i < g_io_events_buffered_per_rank; i++) {
             tw_eventq_push(&g_io_free_events, tw_eventq_pop(&g_tw_pe[0]->free_q));
         }
-        pe->stats.s_rio = (tw_clock_read() - start);
+        pe->stats.s_rio_load = (tw_clock_read() - start);
 #endif
     }
 

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -424,9 +424,11 @@ static tw_pe * setup_pes(void) {
         tw_eventq_alloc(&pe->free_q, num_events_per_pe);
         pe->abort_event = tw_eventq_shift(&pe->free_q);
 #ifdef USE_RIO
+        tw_clock start = tw_clock_read();
         for (i = 0; i < g_io_events_buffered_per_rank; i++) {
             tw_eventq_push(&g_io_free_events, tw_eventq_pop(&g_tw_pe[0]->free_q));
         }
+        pe->stats.s_rio = (tw_clock_read() - start);
 #endif
     }
 

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -123,7 +123,7 @@ tw_stats(tw_pe * me)
 	show_lld("Event Ties Detected in PE Queues", s.s_pe_event_ties);
         if(g_tw_synchronization_protocol == CONSERVATIVE)
             printf("\t%-50s %11.9lf\n",
-               "Minimum TS Offset Detected in Conservative Mode",  
+               "Minimum TS Offset Detected in Conservative Mode",
                (double) s.s_min_detected_offset);
 	show_2f("Efficiency", 100.0 * (1.0 - ((double) s.s_e_rbs / (double) s.s_net_events)));
 	show_lld("Total Remote (shared mem) Events Processed", s.s_nsend_loc_remote);
@@ -158,7 +158,7 @@ tw_stats(tw_pe * me)
 	);
 
         show_lld("Total Events Scheduled Past End Time", s.s_events_past_end);
-        
+
 	printf("\nTW Memory Statistics:\n");
 	show_lld("Events Allocated", g_tw_events_per_pe * g_tw_npe);
 	show_lld("Memory Allocated", m_alloc / 1024);

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -86,7 +86,8 @@ tw_stats(tw_pe * me)
         s.s_lz4 += pe->stats.s_lz4;
         s.s_events_past_end += pe->stats.s_events_past_end;
 #ifdef USE_RIO
-        s.s_rio += pe->stats.s_rio;
+        s.s_rio_load += pe->stats.s_rio_load;
+        s.s_rio_lp_init += pe->stats.s_rio_lp_init;
 #endif
 
 		for(i = 0; i < g_tw_nkp; i++)
@@ -191,7 +192,8 @@ tw_stats(tw_pe * me)
     show_4f("LZ4 (de)compression", (double) s.s_lz4 / g_tw_clock_rate);
     show_4f("Buddy system", (double) s.s_buddy / g_tw_clock_rate);
 #ifdef USE_RIO
-    show_4f("RIO Checkpointing", (double) s.s_rio / g_tw_clock_rate);
+    show_4f("RIO Loading", (double) s.s_rio_load / g_tw_clock_rate);
+    show_4f("RIO LP Init", (double) s.s_rio_lp_init / g_tw_clock_rate);
 #endif
 	show_4f("Event Processing", (double) s.s_event_process / g_tw_clock_rate);
 	show_4f("Event Cancel", (double) s.s_cancel_q / g_tw_clock_rate);

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -85,6 +85,9 @@ tw_stats(tw_pe * me)
         s.s_buddy += pe->stats.s_buddy;
         s.s_lz4 += pe->stats.s_lz4;
         s.s_events_past_end += pe->stats.s_events_past_end;
+#ifdef USE_RIO
+        s.s_rio += pe->stats.s_rio;
+#endif
 
 		for(i = 0; i < g_tw_nkp; i++)
 		{
@@ -187,6 +190,9 @@ tw_stats(tw_pe * me)
     show_4f("AVL Tree (insert/delete)", (double) s.s_avl / g_tw_clock_rate);
     show_4f("LZ4 (de)compression", (double) s.s_lz4 / g_tw_clock_rate);
     show_4f("Buddy system", (double) s.s_buddy / g_tw_clock_rate);
+#ifdef USE_RIO
+    show_4f("RIO Checkpointing", (double) s.s_rio / g_tw_clock_rate);
+#endif
 	show_4f("Event Processing", (double) s.s_event_process / g_tw_clock_rate);
 	show_4f("Event Cancel", (double) s.s_cancel_q / g_tw_clock_rate);
 	show_4f("Event Abort", (double) s.s_event_abort / g_tw_clock_rate);


### PR DESCRIPTION
With RIO version 2 there are a number of new features:

- multiple parts-per-rank: each KP becomes a partition, allowing the model developer fine-grained control over buffer utilization and maximum parallelism
- event capturing in conservative mode: events scheduled past end-time are captures for the checkpoint restart
- it works (I'm sure there are more)

I think this is a good candidate for a squash merge.