### PR TITLE
Turned off uploading coveralls data.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -120,7 +120,7 @@ if (COVERALLS)
     # Create the coveralls target.
     coveralls_setup(
         "${COVERAGE_SRCS}" # The source files.
-        ON)                # If we should upload.
+        OFF)               # If we should upload.
 
 endif()
 


### PR DESCRIPTION
So this should be all that's required to turn off those emails.  It leaves some cruft behind but if we gut it we'll lose some functionality such as the ability to not include certain files in the coverage metrics, e.g., the lz4 compression library.  Including that destroys our coverage metrics because we don't exercise much of that library.