### PR TITLE
added in event tracing for sequential execution

### DIFF
--- a/core/instrumentation/st-event-collection.c
+++ b/core/instrumentation/st-event-collection.c
@@ -90,7 +90,7 @@ void st_collect_event_data(tw_event *cev, tw_stime recv_rt, tw_stime duration)
 
         if (g_tw_synchronization_protocol != SEQUENTIAL)
             st_buffer_push(g_st_buffer_evrb, &buffer[0], total_sz);
-        else
+        else if (g_tw_synchronization_protocol == SEQUENTIAL && !g_st_disable_out)
             fwrite(buffer, total_sz, 1, seq_ev_trace);
 
     }

--- a/core/instrumentation/st-event-collection.c
+++ b/core/instrumentation/st-event-collection.c
@@ -75,6 +75,8 @@ void st_collect_event_data(tw_event *cev, tw_stime recv_rt, tw_stime duration)
         index += sizeof(tw_lpid);
         memcpy(&buffer[index], &cev->recv_ts, sizeof(tw_stime));
         index += sizeof(tw_stime);
+        memcpy(&buffer[index], &cev->send_ts, sizeof(tw_stime));
+        index += sizeof(tw_stime);
         memcpy(&buffer[index], &recv_rt, sizeof(tw_stime));
         index += sizeof(tw_stime);
         if (g_st_ev_trace == FULL_TRACE)
@@ -86,7 +88,11 @@ void st_collect_event_data(tw_event *cev, tw_stime recv_rt, tw_stime duration)
         if (index != g_st_buf_size)
             printf("WARNING: size of data being pushed to buffer is incorrect!\n");
 
-        st_buffer_push(g_st_buffer_evrb, &buffer[0], total_sz);
+        if (g_tw_synchronization_protocol != SEQUENTIAL)
+            st_buffer_push(g_st_buffer_evrb, &buffer[0], total_sz);
+        else
+            fwrite(buffer, total_sz, 1, seq_ev_trace);
+
     }
     g_st_stat_comp_ctr += tw_clock_read() - start_cycle_time;
 }

--- a/core/instrumentation/st-stats-buffer.h
+++ b/core/instrumentation/st-stats-buffer.h
@@ -33,6 +33,7 @@ extern int g_st_buffer_free_percent;
 extern MPI_File g_st_gvt_fh;
 extern MPI_File g_st_rt_fh;
 extern MPI_File g_st_evrb_fh;
+extern FILE *seq_ev_trace;
 
 st_stats_buffer *st_buffer_init(char *suffix, MPI_File *fh);
 void st_buffer_push(st_stats_buffer *buffer, char *data, int size);

--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -94,6 +94,7 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
   e->dest_lp = (tw_lp *) dest_gid;
   e->src_lp = sender;
   e->recv_ts = recv_ts;
+  e->send_ts = tw_now(sender);
   e->critical_path = sender->critical_path + 1;
 
   tw_free_output_messages(e, 0);

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -320,6 +320,7 @@ struct tw_event {
 
     tw_peid      send_pe;
     tw_lpid      send_lp;           /**< @brief sending LP ID for data collection uses */
+    tw_stime     send_ts;
 
 #ifdef ROSS_MEMORY
     tw_memory   *memory;

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -420,6 +420,7 @@ void tw_sched_init(tw_pe * me) {
 /*************************************************************************/
 
 void tw_scheduler_sequential(tw_pe * me) {
+    tw_clock ev_start;
     tw_stime gvt = 0.0;
 
     if(tw_nnodes() > 1) {
@@ -451,7 +452,10 @@ void tw_scheduler_sequential(tw_pe * me) {
 
         reset_bitfields(cev);
         clp->critical_path = ROSS_MAX(clp->critical_path, cev->critical_path)+1;
+        ev_start = tw_clock_read();
         (*clp->type->event)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
+        if (g_st_ev_trace == FULL_TRACE)
+            st_collect_event_data(cev, tw_clock_read() / g_tw_clock_rate, tw_clock_read() - ev_start);
         if (*clp->type->commit) {
             (*clp->type->commit)(clp->cur_state, &cev->cv, tw_event_data(cev), clp);
         }


### PR DESCRIPTION
Just made some minor tweaks in what's being collected in the event tracing functionality, as well as making sure it works for sequential mode.  It works the same way as described in the [ROSS Instrumentation](http://carothersc.github.io/ROSS/feature/instrumentation.html) blog post.

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
