### PR TITLE
Improving coverage by testing event hashing implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ script:
  - make
  - CTEST_OUTPUT_ON_FAILURE=1 make test
  - make coveralls
+ - cd ..
+ - mkdir build2 && cd build2
+ - ARCH=x86_64 CC=mpicc MPICH_CC=clang cmake -DAVL_TREE=OFF -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug -DROSS_BUILD_MODELS=ON ..
+ - make
+ - CTEST_OUTPUT_ON_FAILURE=1 make test
+ - make coveralls
 branches:
   only: master
 after_success:


### PR DESCRIPTION
Just trying to grab some low-hanging fruit insofar as coverage is concerned.  Our old hashing implementation took up a vast majority of the hash-quadratic.c file which remains largely untouched due to the AVL tree implementation.  We can exercise the old code by disabling the AVL tree as I did in the travis configuration.  Hopefully this should be able to get the coverage for that file up as it currently is ~20%.

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work