### PR TITLE
fixed deadlock bug in instrumentation

### DIFF
--- a/core/instrumentation/st-stats-buffer.c
+++ b/core/instrumentation/st-stats-buffer.c
@@ -179,7 +179,7 @@ void st_buffer_finalize(st_stats_buffer *buffer, int type)
 {
     MPI_File *fh;
     // check if any data needs to be written out
-    if (!g_st_disable_out && buffer->count)
+    if (!g_st_disable_out)
         st_buffer_write(buffer, 1, type);
 
     if (g_tw_mynode == g_tw_masternode)


### PR DESCRIPTION
Running NeMo with event tracing in optimistic uncovered a bug in the instrumentation code that sometimes causes deadlock.
---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [x] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [x] One or more TravisCI tests should be created (and they should pass)
- [x] Through the TravisCI tests, coverage should increase
- [x] Test with CODES to ensure everything continues to work
