### PR TITLE
Adding some info to conservative sync errors

### DIFF
--- a/core/ross-inline.h
+++ b/core/ross-inline.h
@@ -54,7 +54,7 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
   tw_stime	 recv_ts;
 
   if (offset_ts < 0.0) {
-    tw_error(TW_LOC, "Cannot send events into the past!\n");
+    tw_error(TW_LOC, "Cannot send events into the past! Sending LP: %lu\n", sender->gid);
   }
 
   send_pe = sender->pe;
@@ -92,6 +92,7 @@ tw_event_new(tw_lpid dest_gid, tw_stime offset_ts, tw_lp * sender)
   }
 
   e->dest_lp = (tw_lp *) dest_gid;
+  e->dest_lpid = dest_gid;
   e->src_lp = sender;
   e->recv_ts = recv_ts;
   e->send_ts = tw_now(sender);

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -320,6 +320,7 @@ struct tw_event {
 
     tw_peid      send_pe;
     tw_lpid      send_lp;           /**< @brief sending LP ID for data collection uses */
+    tw_lpid      dest_lpid;
     tw_stime     send_ts;
 
 #ifdef ROSS_MEMORY

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -36,10 +36,11 @@ void tw_event_send(tw_event * event) {
     //Trap lookahead violations
     if (g_tw_synchronization_protocol == CONSERVATIVE) {
         if (recv_ts - tw_now(src_lp) < g_tw_lookahead) {
-            tw_error(TW_LOC, "Lookahead violation: decrease g_tw_lookahead\n"
+            tw_error(TW_LOC, "Lookahead violation: decrease g_tw_lookahead %f\n"
                     "Event causing violation: src LP: %lu, src PE: %lu\n"
                     "dest LP %lu, dest PE %lu, recv_ts %f\n",
-                    src_lp->gid, send_pe->id, event->dest_lpid, dest_peid, recv_ts);
+                    g_tw_lookahead, src_lp->gid, send_pe->id, event->dest_lpid, 
+                    dest_peid, recv_ts);
         }
     }
 

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -29,10 +29,17 @@ void tw_event_send(tw_event * event) {
     }
 #endif
 
+    // call LP remote mapping function to get dest_pe
+    dest_peid = (*src_lp->type->map) ((tw_lpid) event->dest_lp);
+    event->send_lp = src_lp->gid;
+
     //Trap lookahead violations
     if (g_tw_synchronization_protocol == CONSERVATIVE) {
         if (recv_ts - tw_now(src_lp) < g_tw_lookahead) {
-            tw_error(TW_LOC, "Lookahead violation: decrease g_tw_lookahead");
+            tw_error(TW_LOC, "Lookahead violation: decrease g_tw_lookahead\n"
+                    "Event causing violation: src LP: %lu, src PE: %lu\n"
+                    "dest LP %lu, dest PE %lu, recv_ts %f\n",
+                    src_lp->gid, send_pe->id, event->dest_lpid, dest_peid, recv_ts);
         }
     }
 
@@ -41,10 +48,6 @@ void tw_event_send(tw_event * event) {
     }
 
     link_causality(event, send_pe->cur_event);
-
-    // call LP remote mapping function to get dest_pe
-    dest_peid = (*src_lp->type->map) ((tw_lpid) event->dest_lp);
-    event->send_lp = src_lp->gid;
 
     if (dest_peid == g_tw_mynode) {
         event->dest_lp = tw_getlocal_lp((tw_lpid) event->dest_lp);

--- a/core/tw-sched.c
+++ b/core/tw-sched.c
@@ -559,8 +559,10 @@ void tw_scheduler_conservative(tw_pe * me) {
             ckp = clp->kp;
             me->cur_event = cev;
             if( ckp->last_time > cev->recv_ts ){
-                tw_error(TW_LOC, "Found KP last time %lf > current event time %lf for LP %d",
-                ckp->last_time, cev->recv_ts, clp->gid );
+                tw_error(TW_LOC, "Found KP last time %lf > current event time %lf for LP %d, PE %lu"
+                        "src LP %lu, src PE %lu",
+                ckp->last_time, cev->recv_ts, clp->gid, clp->pe->id,
+                cev->send_lp, cev->send_pe);
             }
             ckp->last_time = cev->recv_ts;
 

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -20,6 +20,7 @@ static const tw_optdef kernel_options[] = {
     TWOPT_UINT("extramem", g_tw_events_per_pe_extra, "Number of extra events allocated per PE."),
     TWOPT_UINT("buddy-size", g_tw_buddy_alloc, "delta encoding buddy system allocation (2^X)"),
     TWOPT_UINT("lz4-knob", g_tw_lz4_knob, "LZ4 acceleration factor (higher = faster)"),
+    TWOPT_STIME("cons-lookahead", g_tw_lookahead, "Set g_tw_lookahead"),
     TWOPT_ULONGLONG("max-opt-lookahead", g_tw_max_opt_lookahead, "Optimistic simulation: maximum lookahead allowed in virtual clock time"),
 #ifdef AVL_TREE
     TWOPT_UINT("avl-size", g_tw_avl_node_count, "AVL Tree contains 2^avl-size nodes"),


### PR DESCRIPTION
Just a couple of minor changes.  Some additional output (src/dest LP, etc) was requested for lookahead violation and another conservative mode errors. Also added in a command line option to set g_tw_lookahead.  

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
