### PR TITLE
Changing all events to have an event_id

### DIFF
--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -521,8 +521,8 @@ send_begin(tw_pe *me)
       dest_node = tw_net_onnode((*e->src_lp->type->map)
 				((tw_lpid) e->dest_lp));
 
-      if(!e->state.cancel_q)
-	e->event_id = (tw_eventid) ++me->seq_num;
+      //if(!e->state.cancel_q)
+	//e->event_id = (tw_eventid) ++me->seq_num;
 
       e->send_pe = (tw_peid) g_tw_mynode;
       e->send_lp = e->src_lp->gid;

--- a/core/tw-event.c
+++ b/core/tw-event.c
@@ -29,6 +29,9 @@ void tw_event_send(tw_event * event) {
     }
 #endif
 
+     // moved from network-mpi.c in order to give all events a seq_num
+	event->event_id = (tw_eventid) ++send_pe->seq_num;
+
     // call LP remote mapping function to get dest_pe
     dest_peid = (*src_lp->type->map) ((tw_lpid) event->dest_lp);
     event->send_lp = src_lp->gid;


### PR DESCRIPTION
A deterministic tie breaking scheme was added to the splay tree, but it assumes that all events are given an event_id. However ROSS was only giving remote events an id. 

@carothersc, I've only briefly tested so far to make sure it doesn't break, but I'm going to do some more to see if we do get determinism now. 
---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [ ] Test with CODES to ensure everything continues to work
