### PR TITLE
Minor timing changes

### DIFF
--- a/core/gvt/mpi_allreduce.c
+++ b/core/gvt/mpi_allreduce.c
@@ -111,13 +111,16 @@ tw_gvt_step2(tw_pe *me)
 	tw_stime lvt;
 	tw_stime gvt;
 
+    tw_clock net_start;
 	tw_clock start = tw_clock_read();
 
 	if(me->gvt_status != TW_GVT_COMPUTE)
 		return;
 	while(1)
 	  {
+        net_start = tw_clock_read();
 	    tw_net_read(me);
+        me->stats.s_net_read += tw_clock_read() - net_start;
 
 	    // send message counts to create consistent cut
 	    local_white = me->s_nwhite_sent - me->s_nwhite_recv;

--- a/core/instrumentation/st-event-trace.c
+++ b/core/instrumentation/st-event-trace.c
@@ -46,6 +46,6 @@ void st_collect_event_data(tw_event *cev, tw_stime recv_rt)
             fwrite(buffer, total_sz, 1, seq_ev_trace);
 
     }
-    g_st_stat_comp_ctr += tw_clock_read() - start_cycle_time;
+    g_tw_pe[0]->stats.s_stat_comp += tw_clock_read() - start_cycle_time;
 }
 

--- a/core/instrumentation/st-instrumentation.c
+++ b/core/instrumentation/st-instrumentation.c
@@ -3,8 +3,6 @@
 
 char g_st_stats_out[INST_MAX_LENGTH] = {0};
 char g_st_stats_path[4096] = {0};
-tw_clock g_st_stat_write_ctr = 0;
-tw_clock g_st_stat_comp_ctr = 0;
 int g_st_granularity = 0;
 int g_st_disable_out = 0;
 

--- a/core/instrumentation/st-instrumentation.h
+++ b/core/instrumentation/st-instrumentation.h
@@ -70,8 +70,6 @@ struct sample_metadata
 
 extern char g_st_stats_out[INST_MAX_LENGTH];
 extern char g_st_stats_path[INST_MAX_LENGTH];
-extern tw_clock g_st_stat_write_ctr;
-extern tw_clock g_st_stat_comp_ctr;
 extern int g_st_granularity;
 extern int g_st_disable_out;
 

--- a/core/instrumentation/st-instrumentation.h
+++ b/core/instrumentation/st-instrumentation.h
@@ -119,6 +119,7 @@ struct st_pe_stats{
     float efficiency;
 
     float s_net_read;
+    float s_net_other;
     float s_gvt;
     float s_fossil_collect;
     float s_event_abort;

--- a/core/instrumentation/st-model-data.c
+++ b/core/instrumentation/st-model-data.c
@@ -88,6 +88,6 @@ void st_collect_model_data(tw_pe *pe, tw_stime current_rt, int stats_type)
                 fwrite(buffer, total_sz, 1, seq_model);
         }
     }
-    g_st_stat_comp_ctr += tw_clock_read() - start_cycle_time;
+    pe->stats.s_stat_comp += tw_clock_read() - start_cycle_time;
 }
 

--- a/core/instrumentation/st-sim-engine.c
+++ b/core/instrumentation/st-sim-engine.c
@@ -79,6 +79,7 @@ void st_collect_engine_data_pes(tw_pe *pe, sample_metadata *sample_md, tw_statis
     // TODO set a starting clock rate and subtract that from the counters?
     // because PEs on different nodes will probably have different starting points for cycle counters
     pe_stats.s_net_read = (float)(pe->stats.s_net_read - last_pe_stats[col_type].s_net_read) / g_tw_clock_rate;
+    pe_stats.s_net_other = (float)(pe->stats.s_net_other - last_pe_stats[col_type].s_net_other) / g_tw_clock_rate;
     pe_stats.s_gvt = (float)(pe->stats.s_gvt - last_pe_stats[col_type].s_gvt) / g_tw_clock_rate;
     pe_stats.s_fossil_collect = (float)(pe->stats.s_fossil_collect - last_pe_stats[col_type].s_fossil_collect) / g_tw_clock_rate;
     pe_stats.s_event_abort = (float)(pe->stats.s_event_abort - last_pe_stats[col_type].s_event_abort) / g_tw_clock_rate;

--- a/core/instrumentation/st-sim-engine.c
+++ b/core/instrumentation/st-sim-engine.c
@@ -39,7 +39,7 @@ void st_collect_engine_data(tw_pe *pe, int col_type)
             st_collect_engine_data_lps(pe, lp, &sample_md, &s, col_type);
         }
     }
-    g_st_stat_comp_ctr += tw_clock_read() - start_time;
+    pe->stats.s_stat_comp += tw_clock_read() - start_time;
 }
 
 void st_collect_engine_data_pes(tw_pe *pe, sample_metadata *sample_md, tw_statistics *s, int col_type)

--- a/core/instrumentation/st-stats-buffer.c
+++ b/core/instrumentation/st-stats-buffer.c
@@ -143,6 +143,7 @@ void st_buffer_write(int end_of_sim, int type)
     int my_write_size = 0;
     int i;
     int write_sizes[tw_nnodes()];
+    tw_clock start_cycle_time = tw_clock_read();
 
     my_write_size = g_st_buffer[type]->count;
 
@@ -169,11 +170,10 @@ void st_buffer_write(int end_of_sim, int type)
         //printf("rank %ld writing %d bytes at offset %lld (prev_offsets[ANALYSIS_LP] = %lld)\n", g_tw_mynode, my_write_size, offset, prev_offsets[type]);
         // dump buffer to file
         MPI_Status status;
-
-        //MPI_Comm_split(MPI_COMM_ROSS, file_number, file_position, &file_comm);
-        tw_clock start_cycle_time = tw_clock_read();;
+        g_tw_pe[0]->stats.s_stat_comp += tw_clock_read() - start_cycle_time;
+        start_cycle_time = tw_clock_read();
         MPI_File_write_at_all(*fh, offset, st_buffer_read_ptr(g_st_buffer[type]), my_write_size, MPI_BYTE, &status);
-        g_st_stat_write_ctr += tw_clock_read() - start_cycle_time;
+        g_tw_pe[0]->stats.s_stat_write += tw_clock_read() - start_cycle_time;
 
         // reset the buffer
         g_st_buffer[type]->write_pos = 0;
@@ -181,6 +181,8 @@ void st_buffer_write(int end_of_sim, int type)
         g_st_buffer[type]->count = 0;
         buffer_overflow_warned = 0;
     }
+    else
+        g_tw_pe[0]->stats.s_stat_comp += tw_clock_read() - start_cycle_time;
 }
 
 /* make sure we write out any remaining buffer data */

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -786,29 +786,11 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 
   if(MPI_Reduce(&(s->s_net_events),
 		&me->stats.s_net_events,
-		16,
+		17,
 		MPI_UNSIGNED_LONG_LONG,
 		MPI_SUM,
 		(int)g_tw_masternode,
 		MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-  if(MPI_Reduce(&s->s_total,
-		&me->stats.s_total,
-		8,
-		MPI_UNSIGNED_LONG_LONG,
-		MPI_MAX,
-		(int)g_tw_masternode,
-		MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-  if(MPI_Reduce(&s->s_pe_event_ties,
-        &me->stats.s_pe_event_ties,
-        1,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_SUM,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
   if(MPI_Reduce(&s->s_min_detected_offset,
@@ -820,31 +802,13 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
         MPI_COMM_ROSS) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
-  if(MPI_Reduce(&s->s_avl,
-        &me->stats.s_avl,
-        1,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_MAX,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-    if (MPI_Reduce(&s->s_buddy,
-        &me->stats.s_buddy,
-        1,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_MAX,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-    if (MPI_Reduce(&s->s_lz4,
-        &me->stats.s_lz4,
-        1,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_MAX,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
+  if(MPI_Reduce(&s->s_total,
+		&me->stats.s_total,
+		14,
+		MPI_UNSIGNED_LONG_LONG,
+		MPI_MAX,
+		(int)g_tw_masternode,
+		MPI_COMM_ROSS) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
     if (MPI_Reduce(&s->s_events_past_end,
@@ -858,16 +822,7 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 
     if (MPI_Reduce(&g_st_stat_comp_ctr,
         &me->stats.s_stat_comp,
-        1,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_MAX,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-    if (MPI_Reduce(&g_st_stat_write_ctr,
-        &me->stats.s_stat_write,
-        1,
+        2,
         MPI_UNSIGNED_LONG_LONG,
         MPI_MAX,
         (int)g_tw_masternode,

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -348,6 +348,7 @@ static void
 recv_finish(tw_pe *me, tw_event *e, char * buffer)
 {
   tw_pe		*dest_pe;
+  tw_clock start;
 
 #if ROSS_MEMORY
   tw_memory	*memory;
@@ -459,7 +460,9 @@ recv_finish(tw_pe *me, tw_event *e, char * buffer)
     /* Fast case, we are sending to our own PE and
      * there is no rollback caused by this send.
      */
+    start = tw_clock_read();
     tw_pq_enqueue(dest_pe->pq, e);
+    dest_pe->stats.s_pq += tw_clock_read() - start;
     return;
   }
 

--- a/core/network-mpi.c
+++ b/core/network-mpi.c
@@ -802,9 +802,9 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
         MPI_COMM_ROSS) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
-  if(MPI_Reduce(&s->s_total,
+  if(MPI_Reduce(&(s->s_total),
 		&me->stats.s_total,
-		14,
+		16,
 		MPI_UNSIGNED_LONG_LONG,
 		MPI_MAX,
 		(int)g_tw_masternode,
@@ -813,29 +813,11 @@ tw_net_statistics(tw_pe * me, tw_statistics * s)
 
     if (MPI_Reduce(&s->s_events_past_end,
         &me->stats.s_events_past_end,
-        1,
+        3,
         MPI_UNSIGNED_LONG_LONG,
         MPI_SUM,
         (int)g_tw_masternode,
         MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-    if (MPI_Reduce(&g_st_stat_comp_ctr,
-        &me->stats.s_stat_comp,
-        2,
-        MPI_UNSIGNED_LONG_LONG,
-        MPI_MAX,
-        (int)g_tw_masternode,
-        MPI_COMM_ROSS) != MPI_SUCCESS)
-    tw_error(TW_LOC, "Unable to reduce statistics!");
-
-  if(MPI_Reduce(&(s->s_alp_nevent_processed),
-		&me->stats.s_alp_nevent_processed,
-		2,
-		MPI_UNSIGNED_LONG_LONG,
-		MPI_SUM,
-		(int)g_tw_masternode,
-		MPI_COMM_ROSS) != MPI_SUCCESS)
     tw_error(TW_LOC, "Unable to reduce statistics!");
 
 #ifdef USE_RIO

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -140,6 +140,7 @@ struct tw_statistics {
     tw_stime s_min_detected_offset;
 
     tw_clock s_total;
+    tw_clock s_init;
     tw_clock s_net_read;
     tw_clock s_net_other;
     tw_clock s_gvt;

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -156,11 +156,11 @@ struct tw_statistics {
     tw_clock s_avl;
     tw_clock s_buddy;
     tw_clock s_lz4;
+    tw_clock s_stat_comp;
+    tw_clock s_stat_write;
 
     tw_stat s_events_past_end;
 
-    tw_clock s_stat_comp;
-    tw_clock s_stat_write;
     tw_stat s_alp_nevent_processed;
     tw_stat s_alp_e_rbs;
 

--- a/core/ross-types.h
+++ b/core/ross-types.h
@@ -141,6 +141,7 @@ struct tw_statistics {
 
     tw_clock s_total;
     tw_clock s_net_read;
+    tw_clock s_net_other;
     tw_clock s_gvt;
     tw_clock s_fossil_collect;
 

--- a/core/tw-kp.c
+++ b/core/tw-kp.c
@@ -23,6 +23,7 @@ void
 tw_kp_rollback_to(tw_kp * kp, tw_stime to)
 {
         tw_event       *e;
+        tw_clock pq_start;
 
         kp->s_rb_total++;
         // instrumentation
@@ -56,7 +57,9 @@ tw_kp_rollback_to(tw_kp * kp, tw_stime to)
                 /*
                  * place event back into priority queue
                  */
+                pq_start = tw_clock_read();
                 tw_pq_enqueue(kp->pe->pq, e);
+                kp->pe->stats.s_pq += tw_clock_read() - pq_start;
         }
 }
 
@@ -66,6 +69,7 @@ tw_kp_rollback_event(tw_event * event)
     tw_event       *e = NULL;
     tw_kp          *kp;
     tw_pe          *pe;
+    tw_clock pq_start;
 
     kp = event->dest_lp->kp;
     pe = kp->pe;
@@ -88,7 +92,9 @@ tw_kp_rollback_event(tw_event * event)
 	{
                 kp->last_time = kp->pevent_q.head->recv_ts;
 		tw_event_rollback(e);
+                pq_start = tw_clock_read();
                 tw_pq_enqueue(pe->pq, e);
+                pe->stats.s_pq += tw_clock_read() - pq_start;
 
 		e = tw_eventq_shift(&kp->pevent_q);
         }

--- a/core/tw-setup.c
+++ b/core/tw-setup.c
@@ -10,6 +10,7 @@
 
 static tw_pe *setup_pes(void);
 unsigned int nkp_per_pe = 16;
+static tw_clock init_start = 0;
 
 static const tw_optdef kernel_options[] = {
     TWOPT_GROUP("ROSS Kernel"),
@@ -30,6 +31,7 @@ static const tw_optdef kernel_options[] = {
 
 void tw_init(int *argc, char ***argv) {
     int i;
+    init_start = tw_clock_read();
 #if HAVE_CTIME
     time_t raw_time;
 #endif
@@ -344,6 +346,7 @@ void tw_run(void) {
 #endif
 
     tw_sched_init(me);
+    me->stats.s_init = tw_clock_read() - init_start;
 
     switch(g_tw_synchronization_protocol) {
         case SEQUENTIAL:            // case 1

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -79,6 +79,8 @@ tw_get_stats(tw_pe * me, tw_statistics *s)
         s->s_avl += pe->stats.s_avl;
         s->s_buddy += pe->stats.s_buddy;
         s->s_lz4 += pe->stats.s_lz4;
+        s->s_stat_comp += pe->stats.s_stat_comp;
+        s->s_stat_write += pe->stats.s_stat_write;
         s->s_events_past_end += pe->stats.s_events_past_end;
 #ifdef USE_RIO
         s->s_rio_load += pe->stats.s_rio_load;
@@ -234,8 +236,8 @@ tw_stats(tw_pe *me)
 	show_4f("Primary Rollbacks", (double) s.s_rollback / g_tw_clock_rate);
 	show_4f("Network Read", (double) s.s_net_read / g_tw_clock_rate);
 	show_4f("Other Network", (double) s.s_net_other / g_tw_clock_rate);
-	show_4f("Statistics Computation", (double) s.s_stat_comp / g_tw_clock_rate);
-	show_4f("Statistics Write", (double) s.s_stat_write / g_tw_clock_rate);
+	show_4f("Instrumentation (computation)", (double) s.s_stat_comp / g_tw_clock_rate);
+	show_4f("Instrumentation (write)", (double) s.s_stat_write / g_tw_clock_rate);
 	show_4f("Total Time (Note: Using Running Time above for Speedup)", (double) s.s_total / g_tw_clock_rate);
 #endif
 

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -65,6 +65,7 @@ tw_get_stats(tw_pe * me, tw_statistics *s)
 
 		s->s_total += pe->stats.s_total;
 		s->s_net_read += pe->stats.s_net_read;
+        s->s_net_other += pe->stats.s_net_other;
 		s->s_gvt += pe->stats.s_gvt;
 		s->s_fossil_collect += pe->stats.s_fossil_collect;
 		s->s_event_abort += pe->stats.s_event_abort;
@@ -230,6 +231,7 @@ tw_stats(tw_pe *me)
 	show_4f("Fossil Collect", (double) s.s_fossil_collect / g_tw_clock_rate);
 	show_4f("Primary Rollbacks", (double) s.s_rollback / g_tw_clock_rate);
 	show_4f("Network Read", (double) s.s_net_read / g_tw_clock_rate);
+	show_4f("Other Network", (double) s.s_net_other / g_tw_clock_rate);
 	show_4f("Statistics Computation", (double) s.s_stat_comp / g_tw_clock_rate);
 	show_4f("Statistics Write", (double) s.s_stat_write / g_tw_clock_rate);
 	show_4f("Total Time (Note: Using Running Time above for Speedup)", (double) s.s_total / g_tw_clock_rate);

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -64,6 +64,7 @@ tw_get_stats(tw_pe * me, tw_statistics *s)
 		s->s_nsend_remote_rb += pe->stats.s_nsend_remote_rb;
 
 		s->s_total += pe->stats.s_total;
+		s->s_init += pe->stats.s_init;
 		s->s_net_read += pe->stats.s_net_read;
         s->s_net_other += pe->stats.s_net_other;
 		s->s_gvt += pe->stats.s_gvt;
@@ -215,6 +216,7 @@ tw_stats(tw_pe *me)
 
 #ifdef ROSS_timing
 	printf("\nTW Clock Cycle Statistics (MAX values in secs at %1.4lf GHz):\n", g_tw_clock_rate / 1000000000.0);
+	show_4f("Initialization", (double) s.s_init / g_tw_clock_rate);
 	show_4f("Priority Queue (enq/deq)", (double) s.s_pq / g_tw_clock_rate);
     show_4f("AVL Tree (insert/delete)", (double) s.s_avl / g_tw_clock_rate);
     show_4f("LZ4 (de)compression", (double) s.s_lz4 / g_tw_clock_rate);

--- a/core/tw-stats.c
+++ b/core/tw-stats.c
@@ -5,28 +5,28 @@ static void
 show_lld(const char *name, tw_stat v)
 {
 	printf("\t%-50s %11lld\n", name, v);
-	fprintf(g_tw_csv, "%lld,", v);
+	fprintf(g_tw_csv, ",%lld", v);
 }
 
 static void
 show_2f(const char *name, double v)
 {
 	printf("\t%-50s %11.2f %%\n", name, v);
-	fprintf(g_tw_csv, "%.2f,", v);
+	fprintf(g_tw_csv, ",%.2f", v);
 }
 
 static void
 show_1f(const char *name, double v)
 {
 	printf("\t%-50s %11.1f\n", name, v);
-	fprintf(g_tw_csv, "%.2f,", v);
+	fprintf(g_tw_csv, ",%.2f", v);
 }
 
 static void
 show_4f(const char *name, double v)
 {
 	printf("\t%-50s %11.4lf\n", name, v);
-	fprintf(g_tw_csv, "%.4lf,", v);
+	fprintf(g_tw_csv, ",%.4lf", v);
 }
 
 #endif
@@ -147,7 +147,7 @@ tw_stats(tw_pe *me)
 
 #ifndef ROSS_DO_NOT_PRINT
 	printf("\n\t: Running Time = %.4f seconds\n", s.s_max_run_time);
-	fprintf(g_tw_csv, "%.4f,", s.s_max_run_time);
+	fprintf(g_tw_csv, "%.4f", s.s_max_run_time);
 
 	printf("\nTW Library Statistics:\n");
 	show_lld("Total Events Processed", s.s_nevent_processed);


### PR DESCRIPTION
There's no major changes or features here.  While tracing a weird issue in CODES, I noticed that some cycle counters underestimate the amount of time (e.g., not every call to `tw_net_read()` was timed, so final output was not accurate). Hopefully all those should be good now.  Also added in some additional timers, like initialization time.

I also cleaned up the ross.csv output.  I don't think it was really useful before because it wasn't clear what each column is, and any given simulation run would output two different lines.  So now there's a header added and a run outputs to only one line now. 

edit to add: Since this is just some relatively minor changes and not a new feature, there's no accompanying blog post and no new TravisCI tests.
---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [ ] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [ ] One or more TravisCI tests should be created (and they should pass)
- [ ] Through the TravisCI tests, coverage should increase
- [x] Test with CODES to ensure everything continues to work
