### PR TITLE
Change g_tw_clock_rate to unsigned long long

### DIFF
--- a/core/clock/amd64.c
+++ b/core/clock/amd64.c
@@ -14,7 +14,7 @@
 static const tw_optdef clock_opts [] =
 {
 	TWOPT_GROUP("ROSS Timing"),
-	TWOPT_STIME("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+	TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
 	TWOPT_END()
 };
 

--- a/core/clock/bgl.c
+++ b/core/clock/bgl.c
@@ -3,7 +3,7 @@
 static const tw_optdef clock_opts [] =
 {
 	TWOPT_GROUP("ROSS Timing"),
-	TWOPT_STIME("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+	TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
 	TWOPT_END()
 };
 

--- a/core/clock/bgq.c
+++ b/core/clock/bgq.c
@@ -3,7 +3,7 @@
 static const tw_optdef clock_opts [] =
 {
 	TWOPT_GROUP("ROSS Timing"),
-	TWOPT_STIME("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+	TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
 	TWOPT_END()
 };
 

--- a/core/clock/i386.c
+++ b/core/clock/i386.c
@@ -10,7 +10,7 @@
 static const tw_optdef clock_opts [] =
 {
 	TWOPT_GROUP("ROSS Timing"),
-	TWOPT_STIME("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+	TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
 	TWOPT_END()
 };
 

--- a/core/clock/ppc64le.c
+++ b/core/clock/ppc64le.c
@@ -6,7 +6,7 @@ extern unsigned long long g_tw_clock_rate = 512000000.0;
 static const tw_optdef clock_opts [] =
 {
 	TWOPT_GROUP("ROSS Timing"),
-	TWOPT_STIME("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
+	TWOPT_ULONGLONG("clock-rate", g_tw_clock_rate, "CPU Clock Rate"),
 	TWOPT_END()
 };
 

--- a/core/clock/ppc64le.c
+++ b/core/clock/ppc64le.c
@@ -1,7 +1,7 @@
 #include <ross.h>
 
 // rest from default to 512MHz as that's the timebase for the POWER9 system.
-extern tw_stime g_tw_clock_rate = 512000000.0;
+extern unsigned long long g_tw_clock_rate = 512000000.0;
 
 static const tw_optdef clock_opts [] =
 {

--- a/core/ross-extern.h
+++ b/core/ross-extern.h
@@ -82,7 +82,7 @@ extern const tw_optdef *tw_clock_setup();
 extern void tw_clock_init(tw_pe * me);
 extern tw_clock tw_clock_now(tw_pe * me);
 extern tw_clock tw_clock_read();
-extern tw_stime g_tw_clock_rate;
+extern unsigned long long g_tw_clock_rate;
 
 /*
  * tw-event.c

--- a/core/ross-global.c
+++ b/core/ross-global.c
@@ -104,7 +104,7 @@ FILE		*g_tw_csv = NULL;
  *
  */
 
-tw_stime g_tw_clock_rate=1000000000.0; // Default to 1 GHz
+unsigned long long g_tw_clock_rate=1000000000.0; // Default to 1 GHz
 
 // LP Type Mapping
 tw_lptype * g_tw_lp_types = NULL;


### PR DESCRIPTION
This change is in response to issue #98. Prior to this, g_tw_clock_rate
has been of type tw_stime which is an alias for double. Unsigned long long
makes greater sense.

---

If this merge represents a feature addition to ROSS, the following items must be completed before the branch will be merged:

- [x] Document the feature on the blog (See the [Contributing guide](https://github.com/carothersc/ROSS/blob/gh-pages/CONTRIBUTING.md) in the gh-pages branch).
  Include a link to your blog post in the Pull Request.
- [x] One or more TravisCI tests should be created (and they should pass)
- [x] Through the TravisCI tests, coverage should increase
- [x] Test with CODES to ensure everything continues to work
